### PR TITLE
stop calling notMoving if reportMovementExercise is deactivated

### DIFF
--- a/Muvr/MRExerciseSessionViewController.swift
+++ b/Muvr/MRExerciseSessionViewController.swift
@@ -263,7 +263,7 @@ class MRExerciseSessionViewController : UIPageViewController, UIPageViewControll
     func notMoving() {
         if waitingForUser { return }
         if let x: MRExerciseBlockDelegate = currentPageViewController() { x.notMoving() }
-        if !mode!.reportMovementExercise { pcd.notifyNotMoving() }
+        if mode!.reportMovementExercise { pcd.notifyNotMoving() }
     }
     
     // MARK: MRTrainingPipelineDelegate


### PR DESCRIPTION
Fixes the pebble issue [10 ](https://github.com/muvr/muvr-pebble/issues/10)