### PR TITLE
Fix exercise labelling

### DIFF
--- a/Muvr/Entities/MRManagedClassifiedExercise.swift
+++ b/Muvr/Entities/MRManagedClassifiedExercise.swift
@@ -14,7 +14,6 @@ class MRManagedClassifiedExercise: NSManagedObject {
     
     static func insertNewObject(inManagedObjectContext managedObjectContext: NSManagedObjectContext) -> MRManagedClassifiedExercise {
         let mo = NSEntityDescription.insertNewObjectForEntityForName("MRManagedClassifiedExercise", inManagedObjectContext: managedObjectContext) as! MRManagedClassifiedExercise
-        
         return mo
     }
 
@@ -22,7 +21,7 @@ class MRManagedClassifiedExercise: NSManagedObject {
         let mo = insertNewObject(inManagedObjectContext: managedObjectContext)
         
         mo.exerciseSession = session
-        mo.start = session.start.addSeconds(Int(classifiedExercise.offset))
+        mo.start = NSDate(timeIntervalSince1970: classifiedExercise.offset)
         mo.confidence = classifiedExercise.confidence
         mo.duration = classifiedExercise.duration
         mo.exerciseId = classifiedExercise.exerciseId

--- a/Muvr/MRSessionViewController.swift
+++ b/Muvr/MRSessionViewController.swift
@@ -92,11 +92,10 @@ class MRSessionViewController : UIViewController, UITableViewDataSource {
     @IBAction func shareCSV() {
         if let data = session?.sensorData,
             let sessionId = session?.id,
-            let sessionStart = session?.start.timeIntervalSince1970,
             let labelledExercises = session?.labelledExercises.allObjects as? [MRManagedLabelledExercise],
             let exerciseModel = session?.exerciseModelId,
             let sensorData = try? MKSensorData(decoding: data) {
-                let csvData = sensorData.encodeAsCsv(sessionStart: sessionStart, labelledExercises: labelledExercises)
+                let csvData = sensorData.encodeAsCsv(labelledExercises: labelledExercises)
                 share(csvData, fileName: "\(exerciseModel)_\(sessionId).csv")
         }
     }

--- a/MuvrKit/MKPhoneExerciseSessionClassifier.swift
+++ b/MuvrKit/MKPhoneExerciseSessionClassifier.swift
@@ -105,8 +105,8 @@ public final class MKSessionClassifier : MKExerciseConnectivitySessionDelegate, 
     public func sensorDataConnectivityDidReceiveSensorData(accumulated accumulated: MKSensorData, new: MKSensorData, session: MKExerciseConnectivitySession) {
         guard let exerciseSession = sessions.last else { return }
         
-        // compute the offset from the start of the session
-        let shift = shiftOffset(new.start - accumulated.start)
+        // compute the exercise start date: new.start + exercise offset
+        let shift = shiftOffset(new.start)
         
         dispatch_async(classificationQueue) {
             if let classified = self.classify(exerciseModelId: session.exerciseModelId, sensorData: new) {

--- a/MuvrKit/MKPhoneExerciseSessionClassifier.swift
+++ b/MuvrKit/MKPhoneExerciseSessionClassifier.swift
@@ -105,8 +105,8 @@ public final class MKSessionClassifier : MKExerciseConnectivitySessionDelegate, 
     public func sensorDataConnectivityDidReceiveSensorData(accumulated accumulated: MKSensorData, new: MKSensorData, session: MKExerciseConnectivitySession) {
         guard let exerciseSession = sessions.last else { return }
         
-        // accumulated contains all sensor data (including new)
-        let shift = shiftOffset(accumulated.duration - new.duration)
+        // compute the offset from the start of the session
+        let shift = shiftOffset(new.start - accumulated.start)
         
         dispatch_async(classificationQueue) {
             if let classified = self.classify(exerciseModelId: session.exerciseModelId, sensorData: new) {

--- a/MuvrKit/MKSensorData+EncodingCSV.swift
+++ b/MuvrKit/MKSensorData+EncodingCSV.swift
@@ -10,7 +10,7 @@ private extension NSMutableData {
 
 public extension MKSensorData {
     
-    public func encodeAsCsv(sessionStart sessionStart: MKTimestamp, labelledExercises: [MKLabelledExercise]) -> NSData {
+    public func encodeAsCsv(labelledExercises labelledExercises: [MKLabelledExercise]) -> NSData {
         // export data in CSV format: alwx,alwy,alwz,...,hr,...[,L,I,W,R]
         // alw: Accelerometer left wrist
         // hr: Heart rate
@@ -20,7 +20,7 @@ public extension MKSensorData {
         // R: repetitions
         
         func findLabel(row: Int) -> MKLabelledExercise? {
-            let now = sessionStart + start + (Double(row) / Double(samplesPerSecond))
+            let now = start + (Double(row) / Double(samplesPerSecond))
             
             func sampleBelongsTo(label: MKLabelledExercise) -> Bool {
                 let start = label.start.timeIntervalSince1970

--- a/MuvrKit/MKSensorData.swift
+++ b/MuvrKit/MKSensorData.swift
@@ -149,13 +149,13 @@ public struct MKSensorData {
     /// returns a new MKSensorData containing only the data for the specified period
     ///
     public func slice(offset: MKTimestamp, duration: MKDuration) throws -> MKSensorData {
-        if offset < start || offset + duration > end {
+        if offset < 0 || offset + duration > self.duration {
             throw MKSensorDataError.SliceOutOfRange
         }
-        let sampleStart = dimension * Int(samplesPerSecond) * Int(offset - start)
+        let sampleStart = dimension * Int(samplesPerSecond) * Int(offset)
         let sampleEnd = sampleStart + dimension * Int(samplesPerSecond) * Int(duration)
         let data = samples[sampleStart..<sampleEnd]
-        return try MKSensorData(types: types, start: offset, samplesPerSecond: samplesPerSecond, samples: Array(data))
+        return try MKSensorData(types: types, start: start + offset, samplesPerSecond: samplesPerSecond, samples: Array(data))
     }
     
     ///

--- a/MuvrKit/MKWatchConnectivity.swift
+++ b/MuvrKit/MKWatchConnectivity.swift
@@ -145,9 +145,8 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
             let duration = to.timeIntervalSinceDate(from)
             let sampleCount = 3 * 50 * Int(duration)
             
-            func isInRange(time: NSDate) -> Bool {
-                let ts = time.timeIntervalSince1970
-                return from.timeIntervalSince1970 <= ts && ts <= to.timeIntervalSince1970
+            func isInRange(sample: CMRecordedAccelerometerData) -> Bool {
+                return from.timeIntervalSince1970 <= sample.startDate.timeIntervalSince1970
             }
             
             if simulatedSamples {
@@ -156,10 +155,10 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
             } else {
                 return recorder.accelerometerDataFromDate(from, toDate: to).flatMap { (recordedData: CMSensorDataList) -> MKSensorData? in
                     let samples = recordedData.enumerate().flatMap { (_, e) -> [Float] in
-                        if let data = e as? CMRecordedAccelerometerData where isInRange(data.startDate) {
+                        if let data = e as? CMRecordedAccelerometerData where isInRange(data) {
                             return [Float(data.acceleration.x), Float(data.acceleration.y), Float(data.acceleration.z)]
                         }
-                        NSLog("Received data outside out range: \(e)")
+                        NSLog("Received data outside of range: \(e)")
                         return []
                     }
                     NSLog("Expected \(sampleCount) samples and got \(samples.count)")

--- a/MuvrKit/MKWatchConnectivity.swift
+++ b/MuvrKit/MKWatchConnectivity.swift
@@ -147,7 +147,7 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
             
             if simulatedSamples {
                 let samples = (0..<sampleCount).map { _ in return Float(0) }
-                return try! MKSensorData(types: [.Accelerometer(location: .LeftWrist)], start: 0, samplesPerSecond: 50, samples: samples)
+                return try! MKSensorData(types: [.Accelerometer(location: .LeftWrist)], start: from.timeIntervalSince1970, samplesPerSecond: 50, samples: samples)
             } else {
                 return recorder.accelerometerDataFromDate(from, toDate: to).flatMap { (recordedData: CMSensorDataList) -> MKSensorData? in
                     let samples = recordedData.enumerate().flatMap { (_, e) -> [Float] in
@@ -162,7 +162,7 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
                         NSLog("Not yet flushed buffer. Expected \(sampleCount), got \(samples.count)")
                         return nil
                     }
-                    return try! MKSensorData(types: [.Accelerometer(location: .LeftWrist)], start: 0, samplesPerSecond: 50, samples: samples)
+                    return try! MKSensorData(types: [.Accelerometer(location: .LeftWrist)], start: from.timeIntervalSince1970, samplesPerSecond: 50, samples: samples)
                 }
             }
         }

--- a/MuvrKitTests/MKSensorData+EncodingCSV.swift
+++ b/MuvrKitTests/MKSensorData+EncodingCSV.swift
@@ -6,7 +6,7 @@ class MKSensorDataEncodingCSVTests : XCTestCase {
     
     func testEncodeNoLabels() {
         let sd = try! MKSensorData(types: [.Accelerometer(location: .LeftWrist)], start: 0, samplesPerSecond: 1, samples: [Float](count: 6, repeatedValue: 0))
-        let s = String(data: sd.encodeAsCsv(sessionStart: 0, labelledExercises: []), encoding: NSASCIIStringEncoding)!
+        let s = String(data: sd.encodeAsCsv(labelledExercises: []), encoding: NSASCIIStringEncoding)!
         XCTAssertEqual("0.0,0.0,0.0,,,,\n0.0,0.0,0.0,,,,\n", s)
     }
     
@@ -39,7 +39,7 @@ class MKSensorDataEncodingCSVTests : XCTestCase {
         let sd = try! MKSensorData(types: [.Accelerometer(location: .LeftWrist)], start: 0, samplesPerSecond: 1, samples: [Float](count: 9, repeatedValue: 0))
         let bc = SimpleMKLabelledExercise(exerciseId: "bc", start: NSDate(timeIntervalSince1970: 0), end: NSDate(timeIntervalSince1970: 1), repetitions: 10, intensity: 0.8, weight: 8)
         let te = SimpleMKLabelledExercise(exerciseId: "te", start: NSDate(timeIntervalSince1970: 2), end: NSDate(timeIntervalSince1970: 3), repetitions: 10, intensity: 0.9, weight: 9)
-        let s = String(data: sd.encodeAsCsv(sessionStart: 0, labelledExercises: [bc, te]), encoding: NSASCIIStringEncoding)!
+        let s = String(data: sd.encodeAsCsv(labelledExercises: [bc, te]), encoding: NSASCIIStringEncoding)!
         XCTAssertEqual("0.0,0.0,0.0,bc,0.8,8.0,10\n0.0,0.0,0.0,,,,\n0.0,0.0,0.0,te,0.9,9.0,10\n", s)
     }
     

--- a/MuvrKitTests/MKSensorDataSingleTypeTests.swift
+++ b/MuvrKitTests/MKSensorDataSingleTypeTests.swift
@@ -120,7 +120,7 @@ class MKSensorDataSingleTypeTests : XCTestCase {
     ///
     func testSplitSensorData() {
         let d1 = flatD
-        let d2 = try! d1.slice(14, duration: 8)
+        let d2 = try! d1.slice(2, duration: 8)
         XCTAssertEqual(d2.samples.count, 8 * Int(d1.samplesPerSecond))
         XCTAssertEqual(d2.start, 14)
         XCTAssertEqual(d2.duration, 8)
@@ -132,7 +132,7 @@ class MKSensorDataSingleTypeTests : XCTestCase {
     func testSplitSensorDataWithExceedingDuration() {
         let d1 = flatD
         do {
-            try d1.slice(d1.start + 4, duration: d1.duration - 2)
+            try d1.slice(4, duration: d1.duration - 2)
             XCTFail("Split with exceeding duration passed")
         } catch MKSensorDataError.SliceOutOfRange {
             // expected
@@ -147,7 +147,7 @@ class MKSensorDataSingleTypeTests : XCTestCase {
     func testSplitSensorDataWithOfsetNotInRange() {
         let d1 = flatD
         do {
-            try d1.slice(d1.start - 2, duration: d1.duration - 4)
+            try d1.slice(-1, duration: d1.duration - 4)
             XCTFail("Split with start not in range passed")
         } catch MKSensorDataError.SliceOutOfRange {
             // expected

--- a/Watch Extension/MRSessionProgressGroupRenderer.swift
+++ b/Watch Extension/MRSessionProgressGroupRenderer.swift
@@ -20,7 +20,7 @@ class MRSessionProgressGroupRenderer : NSObject {
         if let (session, props) = MRExtensionDelegate.sharedDelegate().currentSession {
             let text = NSDateComponentsFormatter().stringFromTimeInterval(session.duration)!
             group.titleLabel.setText(session.modelId)
-            group.timeLabel.setText(text)
+            group.timeLabel.setText("\(text) - \(Int(session.duration) * 50)")
             group.statsLabel.setText("R \(props.recorded), S \(props.sent)")
         } else {
             group.titleLabel.setText("Idle")


### PR DESCRIPTION
Sometimes the labelled exercises are shifted and do not match exactly with the accelerometer signal.

<img width="1220" alt="screen shot 2015-11-05 at 4 48 15 p m" src="https://cloud.githubusercontent.com/assets/1948559/10975097/1801fc88-83dd-11e5-99e7-1119811dd3fb.png">

- [x] set start field in MKSensorData
- [x] check that the received accelerometer data is actually in the expected range
- [x] show the number of expected sample on the watch UI