### PR TITLE
Send small data at end of session

### DIFF
--- a/MuvrKit/MKWatchConnectivity.swift
+++ b/MuvrKit/MKWatchConnectivity.swift
@@ -339,7 +339,7 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
             var firstSampleTime: NSDate? = nil
             var encoder: MKSensorDataEncoder? = nil
             // enumerate, creating output only if needed
-            sdl.enumerate().forEach { (_, e)  in
+            sdl.enumerate().forEach { (_, e) in
                 if let data = e as? CMRecordedAccelerometerData where isInRange(data) {
                     // keep track of the first sample time
                     if firstSampleTime == nil { firstSampleTime = data.startDate }

--- a/MuvrKit/MKWatchConnectivity.swift
+++ b/MuvrKit/MKWatchConnectivity.swift
@@ -313,7 +313,7 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
         /// - parameter to: the ending date
         /// - returns: pair of URL containing the encoded data and end date, ``nil`` otherwise
         ///
-        func encodeSamples(from from: NSDate, to: NSDate, alreadyCompleted: Bool) -> (NSURL, NSDate)? {
+        func encodeSamples(from from: NSDate, to: NSDate, lastChunk: Bool) -> (NSURL, NSDate)? {
             let duration = to.timeIntervalSinceDate(from)
             let sampleCount = dimension * MKConnectivitySettings.samplingRate * Int(duration)
             
@@ -355,7 +355,7 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
             if let encoder = encoder {
                 encoder.close()
                 // check for minimum duration
-                if alreadyCompleted && encoder.duration > 0 ||
+                if lastChunk && encoder.duration > 0 ||
                     encoder.duration > MKConnectivitySettings.windowDuration {
                     NSLog("Written \(encoder.startDate!) - \(encoder.endDate!) samples.")
                     return (fileUrl, encoder.endDate!)
@@ -399,7 +399,7 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
                 return
             }
             
-            guard let (fileUrl, end) = encodeSamples(from: from, to: to, alreadyCompleted: props.completed) else {
+            guard let (fileUrl, end) = encodeSamples(from: from, to: to, lastChunk: props.completed) else {
                 NSLog("No sensor data in \(from) - \(to)")
                 return
             }

--- a/MuvrKit/MKWatchConnectivity.swift
+++ b/MuvrKit/MKWatchConnectivity.swift
@@ -313,7 +313,7 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
         /// - parameter to: the ending date
         /// - returns: pair of URL containing the encoded data and end date, ``nil`` otherwise
         ///
-        func encodeSamples(from from: NSDate, to: NSDate) -> (NSURL, NSDate)? {
+        func encodeSamples(from from: NSDate, to: NSDate, alreadyCompleted: Bool) -> (NSURL, NSDate)? {
             let duration = to.timeIntervalSinceDate(from)
             let sampleCount = dimension * MKConnectivitySettings.samplingRate * Int(duration)
             
@@ -339,7 +339,7 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
             var firstSampleTime: NSDate? = nil
             var encoder: MKSensorDataEncoder? = nil
             // enumerate, creating output only if needed
-            sdl.enumerate().forEach { (_, e) in
+            sdl.enumerate().forEach { (_, e)  in
                 if let data = e as? CMRecordedAccelerometerData where isInRange(data) {
                     // keep track of the first sample time
                     if firstSampleTime == nil { firstSampleTime = data.startDate }
@@ -355,7 +355,8 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
             if let encoder = encoder {
                 encoder.close()
                 // check for minimum duration
-                if encoder.duration > MKConnectivitySettings.windowDuration {
+                if alreadyCompleted && encoder.duration > 0 ||
+                    encoder.duration > MKConnectivitySettings.windowDuration {
                     NSLog("Written \(encoder.startDate!) - \(encoder.endDate!) samples.")
                     return (fileUrl, encoder.endDate!)
                 }
@@ -393,12 +394,12 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
             let from = props.accelerometerStart ?? session.start
             let to = props.end ?? NSDate()
             
-            if (to.timeIntervalSinceDate(from) < MKConnectivitySettings.windowDuration) {
+            if (!props.completed && to.timeIntervalSinceDate(from) < MKConnectivitySettings.windowDuration) {
                 NSLog("Skip transfer for chunk smaller than a single window")
                 return
             }
             
-            guard let (fileUrl, end) = encodeSamples(from: from, to: to) else {
+            guard let (fileUrl, end) = encodeSamples(from: from, to: to, alreadyCompleted: props.completed) else {
                 NSLog("No sensor data in \(from) - \(to)")
                 return
             }
@@ -426,7 +427,7 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
         recorder.recordAccelerometerForDuration(43200)
         
         // check whether there is something to be done at all.
-        //NSLog("beginTransfer(); |sessions| = \(sessions.count)")
+        NSLog("beginTransfer(); |sessions| = \(sessions.count)")
         if sessions.isEmpty {
             NSLog("Reachable; no active sessions.")
             return

--- a/MuvrKit/MKWatchExerciseConnectivitySession.swift
+++ b/MuvrKit/MKWatchExerciseConnectivitySession.swift
@@ -82,8 +82,8 @@ public struct MKExerciseSessionProperties {
     /// Indicates whether the props represent completed session
     internal var completed: Bool {
         // a session is completed when ended and all data sent over
-        if let end = end {
-            return end.timeIntervalSinceDate(accelerometerStart!) < MKConnectivitySettings.windowDuration // it's ok to miss the last window
+        if let end = end , let accStart = accelerometerStart {
+            return end.timeIntervalSinceDate(accStart) < MKConnectivitySettings.windowDuration // it's ok to miss the last window
         }
         return false
     }

--- a/MuvrKit/MKWatchExerciseConnectivitySession.swift
+++ b/MuvrKit/MKWatchExerciseConnectivitySession.swift
@@ -82,8 +82,8 @@ public struct MKExerciseSessionProperties {
     /// Indicates whether the props represent completed session
     internal var completed: Bool {
         // a session is completed when ended and all data sent over
-        if let end = end , let accStart = accelerometerStart {
-            return end.timeIntervalSinceDate(accStart) < MKConnectivitySettings.windowDuration // it's ok to miss the last window
+        if let end = end , let accelerometerStart = accelerometerStart {
+            return end.timeIntervalSinceDate(accelerometerStart) < MKConnectivitySettings.windowDuration // it's ok to miss the last window
         }
         return false
     }


### PR DESCRIPTION
Fixes #106 
When the session is closed just after the last sending of data and the remaining data are less than a Window , then it was never sent. The reason was that in normal cases chunks of data too small are ignored. 
This makes the sending of small chunks possible if we are at the last part of a session.

- [x] ready for merge and review