### PR TITLE
Fix session completion

### DIFF
--- a/MuvrKit/MKWatchConnectivity.swift
+++ b/MuvrKit/MKWatchConnectivity.swift
@@ -310,17 +310,17 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
         ///
         /// Encodes all the samples between ``from`` and ``to``. 
         /// - parameter from: the starting date
-        /// - parameter to: the ending date
-        /// - returns: pair of URL containing the encoded data and end date, ``nil`` otherwise
+        /// - parameter to: the session end date (if unknown tries to get the data up to now)
+        /// - returns: tuple of :
+        ///      - URL containing the encoded data
+        ///      - date of last encoded sample
+        ///      - flag indicating if it's the last chunk of data
         ///
-        func encodeSamples(from from: NSDate, to: NSDate, lastChunk: Bool) -> (NSURL, NSDate)? {
-            let duration = to.timeIntervalSinceDate(from)
-            let sampleCount = dimension * MKConnectivitySettings.samplingRate * Int(duration)
+        func encodeSamples(from from: NSDate, to: NSDate?) -> (NSURL, NSDate, Bool)? {
             
             // Indicates if the expected sample is in the requested range
             func isInRange(sample: CMRecordedAccelerometerData) -> Bool {
-                let time = sample.startDate.timeIntervalSince1970
-                return from.timeIntervalSince1970 <= time && time < to.timeIntervalSince1970
+                return from.timeIntervalSince1970 <= sample.startDate.timeIntervalSince1970
             }
             
             let documentsUrl = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomainMask.UserDomainMask, true).first!
@@ -331,38 +331,39 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
                 NSLog("Failed to remove file '\(fileUrl)': \(e)")
             }
             
-            // try to get the data from the recorder
-            guard let sdl = recorder.accelerometerDataFromDate(from, toDate: to) else {
+            // try to get the data from the recorder up to now
+            // even if the end date is set we want to see if there is data after it
+            guard let sdl = recorder.accelerometerDataFromDate(from, toDate: NSDate()) else {
                 NSLog("No data available.")
                 return nil
             }
-            var firstSampleTime: NSDate? = nil
-            var encoder: MKSensorDataEncoder? = nil
+            
+            let encoder: MKSensorDataEncoder? = nil
+            var lastChunk = false
+            
             // enumerate, creating output only if needed
             sdl.enumerate().forEach { (_, e) in
                 if let data = e as? CMRecordedAccelerometerData where isInRange(data) {
-                    // keep track of the first sample time
-                    if firstSampleTime == nil { firstSampleTime = data.startDate }
                     if encoder == nil {
-                        // encoder is needed
                         encoder = MKSensorDataEncoder(target: MKFileSensorDataEncoderTarget(fileUrl: fileUrl), types: recordedTypes, samplesPerSecond: 50)
                     }
-                    // append data to the encoder
-                    encoder!.append([Float(data.acceleration.x), Float(data.acceleration.y), Float(data.acceleration.z)], sampleDate: data.startDate)
+                    if let to = to where data.startDate.timeIntervalSinceDate(to) > 0 {
+                        // found data after session end -> this is the last chunk for this session
+                        lastChunk = true
+                    } else {
+                        // append data to the encoder
+                        encoder.append([Float(data.acceleration.x), Float(data.acceleration.y), Float(data.acceleration.z)], sampleDate: data.startDate)
+                    }
                 }
             }
             // after the loop, check if we have anything to transmit
-            if let encoder = encoder {
+            if let encoder = encoder where lastChunk || encoder.duration > MKConnectivitySettings.windowDuration {
                 encoder.close()
-                // check for minimum duration
-                if lastChunk && encoder.duration > 0 ||
-                    encoder.duration > MKConnectivitySettings.windowDuration {
+                if encoder.duration > 0 {
                     NSLog("Written \(encoder.startDate!) - \(encoder.endDate!) samples.")
-                    return (fileUrl, encoder.endDate!)
                 }
-                return nil
-            }
-            
+                return (fileUrl, encoder.endDate ?? from, lastChunk)
+            }            
             return nil
         }
         
@@ -394,27 +395,27 @@ public final class MKConnectivity : NSObject, WCSessionDelegate {
             let from = props.accelerometerStart ?? session.start
             let to = props.end ?? NSDate()
             
-            if (!props.completed && to.timeIntervalSinceDate(from) < MKConnectivitySettings.windowDuration) {
+            if (!props.ended && to.timeIntervalSinceDate(from) < MKConnectivitySettings.windowDuration) {
                 NSLog("Skip transfer for chunk smaller than a single window")
                 return
             }
             
-            guard let (fileUrl, end) = encodeSamples(from: from, to: to, lastChunk: props.completed) else {
+            guard let (fileUrl, end, lastChunk) = encodeSamples(from: from, to: props.end) else {
                 NSLog("No sensor data in \(from) - \(to)")
                 return
             }
             
             // update the number of recorded samples
-            let updatedProps = sessions.update(session, propsUpdate: { return $0.with(accelerometerEnd: end) })
+            let updatedProps = sessions.update(session) { return $0.with(accelerometerEnd: end).with(completed: lastChunk) }
             
             // transfer what we have so far
             transferSensorDataBatch(fileUrl, session: session, props: updatedProps) {
                 // set the expected range of samples on the next call
-                let finalProps = self.sessions.update(session, propsUpdate: { return $0.with(accelerometerStart: end) })
+                let finalProps = self.sessions.update(session) { return $0.with(accelerometerStart: end) }
                 NSLog("Transferred \(finalProps)")
                 
-                // update the session with incremented sent counter
-                if let finalProps = finalProps where finalProps.completed {
+                // Remove session if it was the last chunk of data
+                if lastChunk {
                     NSLog("Removed \(finalProps)")
                     self.sessions.remove(session)
                     // we're done with this session, we can move on to the next one
@@ -551,13 +552,8 @@ private extension MKExerciseSessionProperties {
             "sent" : sent,
         ]
         if let end = end { md["end"] = end.timeIntervalSince1970 }
-        if lastChunk { md["last"] = true }
+        if completed { md["last"] = true }
         return md
-    }
-    
-    /// Indicates if this chunk is the last of the session
-    private var lastChunk: Bool {
-        return ended && recorded >= MKConnectivitySettings.samplesForDuration(duration - MKConnectivitySettings.windowDuration) // ok if miss last data window
     }
     
 }
@@ -602,7 +598,7 @@ private extension MKExerciseSessionProperties {
         }
         
         if  start != nil {
-            self.init(start: start!, accelerometerStart: accStart, accelerometerEnd: accEnd, end: end)
+            self.init(start: start!, accelerometerStart: accStart, accelerometerEnd: accEnd, end: end, completed: false)
         } else {
             return nil
         }

--- a/MuvrKit/MKWatchExerciseConnectivitySession.swift
+++ b/MuvrKit/MKWatchExerciseConnectivitySession.swift
@@ -26,19 +26,22 @@ public struct MKExerciseSessionProperties {
     public let accelerometerStart: NSDate?
     public let accelerometerEnd: NSDate?
     public let end: NSDate?
+    public let completed: Bool
     
     public init(start: NSDate) {
         self.start = start
         self.accelerometerStart = nil
         self.accelerometerEnd = nil
         self.end = nil
+        self.completed = false
     }
     
-    public init(start: NSDate, accelerometerStart: NSDate?, accelerometerEnd: NSDate?, end: NSDate?) {
+    public init(start: NSDate, accelerometerStart: NSDate?, accelerometerEnd: NSDate?, end: NSDate?, completed: Bool) {
         self.start = start
         self.accelerometerStart = accelerometerStart
         self.accelerometerEnd = accelerometerEnd
         self.end = end
+        self.completed = completed
     }
     
     /// Indicates whether the props represent ended session
@@ -48,18 +51,23 @@ public struct MKExerciseSessionProperties {
     
     /// Copies this instance assigning the ``end`` field
     internal func with(end end: NSDate) -> MKExerciseSessionProperties {
-        return MKExerciseSessionProperties(start: start, accelerometerStart: accelerometerStart, accelerometerEnd: accelerometerEnd, end: end)
+        return MKExerciseSessionProperties(start: start, accelerometerStart: accelerometerStart, accelerometerEnd: accelerometerEnd, end: end, completed: completed)
+    }
+    
+    /// Copies this instance assigning the ``completed`` field
+    internal func with(completed completed: Bool) -> MKExerciseSessionProperties {
+        return MKExerciseSessionProperties(start: start, accelerometerStart: accelerometerStart, accelerometerEnd: accelerometerEnd, end: end, completed: completed)
     }
     
     /// Copies this instance assigning the ``accelerometerEnd`` field.
     internal func with(accelerometerEnd accelerometerEnd: NSDate) -> MKExerciseSessionProperties {
         // new recorded value is send + rd (because all recorded samples might not have been sent)
-        return MKExerciseSessionProperties(start: start, accelerometerStart: accelerometerStart, accelerometerEnd: accelerometerEnd, end: end)
+        return MKExerciseSessionProperties(start: start, accelerometerStart: accelerometerStart, accelerometerEnd: accelerometerEnd, end: end, completed: completed)
     }
     
     /// Copies this instance assigning the ``accelerometerStart`` field
     internal func with(accelerometerStart accelerometerStart: NSDate) -> MKExerciseSessionProperties {
-        return MKExerciseSessionProperties(start: start, accelerometerStart: accelerometerStart, accelerometerEnd: accelerometerEnd, end: end)
+        return MKExerciseSessionProperties(start: start, accelerometerStart: accelerometerStart, accelerometerEnd: accelerometerEnd, end: end, completed: completed)
     }
     
     /// Indicates the session duration
@@ -77,15 +85,6 @@ public struct MKExerciseSessionProperties {
     /// Indicates the number of sent samples
     public var sent: Int {
         return accelerometerStart.map { Int($0.timeIntervalSinceDate(start)) * MKConnectivitySettings.samplingRate } ?? 0
-    }
-    
-    /// Indicates whether the props represent completed session
-    internal var completed: Bool {
-        // a session is completed when ended and all data sent over
-        if let end = end , let accelerometerStart = accelerometerStart {
-            return end.timeIntervalSinceDate(accelerometerStart) < MKConnectivitySettings.windowDuration // it's ok to miss the last window
-        }
-        return false
     }
 }
 


### PR DESCRIPTION
Fixes #110 
Some session never complete. They remain active on the watch after session ends because of remaining data to be sent.

Knowing when there is no more data to send is tricky because there may be missing data at then end.

The only way to find out is to check if there is data available after the session end date.

- authorize sending the data if it is the last chunk needed, two case possible
  - the last expected chunk is expected to be smaller than the window
  - the chunk is expected to be bigger than a window but the amount of data provided by the accelerometer amount to less than a window (and no more data will come)

- remove demo session since we do not want junk data sent (was ignored but blocking the next sessions processing)

- [x] ready for merge and review
