### PR TITLE
Fix add label button enabled when session stopped

### DIFF
--- a/Muvr/Base.lproj/Main.storyboard
+++ b/Muvr/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="uAe-Tk-bVz">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="uAe-Tk-bVz">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
         <capability name="Navigation items with more than one left or right bar item" minToolsVersion="7.0"/>
@@ -64,7 +64,7 @@
                                 <items>
                                     <navigationItem title="Session" id="jNZ-Gu-hkV">
                                         <rightBarButtonItems>
-                                            <barButtonItem systemItem="add" id="wAH-mU-GD8">
+                                            <barButtonItem enabled="NO" systemItem="add" id="wAH-mU-GD8">
                                                 <connections>
                                                     <action selector="label:" destination="R8z-14-vmd" id="2pj-XP-7EF"/>
                                                 </connections>
@@ -90,7 +90,7 @@
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="classifiedExercise" textLabel="dOT-nc-bE9" detailTextLabel="rPs-U4-Dlx" style="IBUITableViewCellStyleValue2" id="GI8-GD-9lg">
-                                        <rect key="frame" x="0.0" y="49.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="50" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="GI8-GD-9lg" id="AFF-r8-vjI">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -118,7 +118,7 @@
                                         <animations/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="labelledExercise" textLabel="cZ6-Hv-PIt" detailTextLabel="LiM-7A-DEt" style="IBUITableViewCellStyleValue2" id="Nvq-Lh-Mq1">
-                                        <rect key="frame" x="0.0" y="93.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="94" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Nvq-Lh-Mq1" id="TAK-vw-Nu0">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>

--- a/Muvr/MRSessionViewController.swift
+++ b/Muvr/MRSessionViewController.swift
@@ -14,15 +14,12 @@ class MRSessionViewController : UIViewController, UITableViewDataSource {
     
     // the displayed session
     private var session: MRManagedExerciseSession?
-    // indicates if the displayed session is active (i.e. not finished)
-    private var runningSession: Bool = false
     
     ///
     /// Provides the session to display
     ///
     func setSession(session: MRManagedExerciseSession) {
         self.session = session
-        runningSession = MRAppDelegate.sharedDelegate().currentSession.map { $0 == session } ?? false
     }
     
     ///
@@ -55,11 +52,11 @@ class MRSessionViewController : UIViewController, UITableViewDataSource {
         if let objectId = session?.objectID {
             NSNotificationCenter.defaultCenter().addObserver(self, selector: "sessionDidEnd", name: MRNotifications.CurrentSessionDidEnd.rawValue, object: objectId)
         }
+        addLabelBtn.enabled = session != nil && session?.end == nil
         tableView.reloadData()
     }
     
     override func viewDidLoad() {
-        addLabelBtn.enabled = runningSession
         if let s = session {
             navbar.topItem!.title = "\(s.start.formatTime()) - \(s.exerciseModelId)"
         } else {


### PR DESCRIPTION
Fixes #112 
The notification of end session was ignored when the session is sent to the phone as both New (started) and just Stopped. The reason was that the notification was received by the Session view while it is still building itself (between Load and Appear) so it was ignored. 
I made the buttons enable state depends on the session.end date instead.