### PR TITLE
Fix SliceOutOfRange error

### DIFF
--- a/MuvrKit/MKClassifier.swift
+++ b/MuvrKit/MKClassifier.swift
@@ -229,7 +229,7 @@ struct MKClassifiedExerciseBlock {
         // use the duration to apply correct weights in average computation
         let conf = self.exerciseId == by.exerciseId ? by.confidence : 0.0
         self.confidence = (self.confidence * self.duration + conf * by.duration) / (self.duration + by.duration)
-        self.duration = self.duration + by.duration
+        self.duration = round(100 * self.duration + 100 * by.duration) / 100
     }
 }
 

--- a/MuvrKit/MKSensorData.swift
+++ b/MuvrKit/MKSensorData.swift
@@ -103,11 +103,12 @@ public struct MKSensorData {
     /// returns a new MKSensorData containing only the data for the specified period
     ///
     public func slice(offset: MKTimestamp, duration: MKDuration) throws -> MKSensorData {
-        if offset < 0 || offset + duration > self.duration {
+        let freq = Double(samplesPerSecond)
+        if offset < 0 || offset + duration > self.duration + (1 / freq) { // avoid rounding issues (e.g 4.2000000001)
             throw MKSensorDataError.SliceOutOfRange
         }
-        let sampleStart = dimension * Int(samplesPerSecond) * Int(offset)
-        let sampleEnd = sampleStart + dimension * Int(samplesPerSecond) * Int(duration)
+        let sampleStart = dimension * Int(freq * offset)
+        let sampleEnd = sampleStart + dimension * Int(freq * duration)
         let data = samples[sampleStart..<sampleEnd]
         return try MKSensorData(types: types, start: start + offset, samplesPerSecond: samplesPerSecond, samples: Array(data))
     }


### PR DESCRIPTION
Sometimes session classification crashes because of ``SliceOutOfRange`` error.
it happens when the requested slice did not fit into the existing data. 
(rounding issues, e.g. ``2.400000001 <= 2.4``)