### PR TITLE
Fix calendar scrolling when last day selected

### DIFF
--- a/Muvr/MRSessionsViewController.swift
+++ b/Muvr/MRSessionsViewController.swift
@@ -100,7 +100,7 @@ class MRSessionsViewController : UIViewController, UIPageViewControllerDataSourc
         // today as the day of week, where 1 is the first day of week (e.g. Monday in UK, Sunday in US, etc.)
         let weekDay = NSCalendar.currentCalendar().components(.Weekday, fromDate: today).weekday
         // the end of the week where ``today`` falls into
-        let dateAtEndOfWeek = today.addDays(7 - weekDay)
+        let dateAtEndOfWeek = today.addDays(8 - weekDay)
         
         return date.compare(dateAtEndOfWeek) == .OrderedAscending
     }


### PR DESCRIPTION
When the last day of the week is selected and you scroll to previous week you can no longer go back to current week without selecting another day.

- [x] fix #139 

