### PR TITLE
Remove rounding on duration fusing

### DIFF
--- a/MuvrKit/MKClassifier.swift
+++ b/MuvrKit/MKClassifier.swift
@@ -228,7 +228,7 @@ struct MKClassifiedExerciseBlock {
         // use the duration to apply correct weights in average computation
         let conf = self.exerciseId == by.exerciseId ? by.confidence : 0.0
         self.confidence = (self.confidence * self.duration + conf * by.duration) / (self.duration + by.duration)
-        self.duration = round(100 * self.duration + 100 * by.duration) / 100
+        self.duration = self.duration + by.duration
     }
 }
 


### PR DESCRIPTION
Rounding the duration sometimes leads to off by one errors when using the duration to access slice data. The rounding will lead to the duration being longer and hence the app will try to access an example that does not exist and crash.

- [x] Ready for review