### PR TITLE
Save all label values

### DIFF
--- a/Muvr/MRSessionViewController.swift
+++ b/Muvr/MRSessionViewController.swift
@@ -194,8 +194,8 @@ class MRSessionViewController : UIViewController, MRExerciseViewDelegate {
         case .Ready(let exerciseDetail):
             state = .ComingUp(exerciseDetail: exerciseDetail)
         case .InExercise(let exerciseDetail, let start):
-            let (labels, _) = session.predictExerciseLabelsForExerciseDetail(exerciseDetail)
-            state = .Done(exerciseDetail: exerciseDetail, labels: labels, start: start, duration: NSDate().timeIntervalSinceDate(start))
+            let (labels, missing) = session.predictExerciseLabelsForExerciseDetail(exerciseDetail)
+            state = .Done(exerciseDetail: exerciseDetail, labels: labels + missing.filter { !labels.contains($0) } , start: start, duration: NSDate().timeIntervalSinceDate(start))
             session.clearClassificationHints()
         case .Done(let exerciseDetail, let labels, let start, let duration):
             // The user has completed the exercise, and accepted our labels

--- a/MuvrUITests/MuvrUITests.swift
+++ b/MuvrUITests/MuvrUITests.swift
@@ -42,6 +42,11 @@ class MuvrUITests: XCTestCase {
         // Don't set any labels
         app.otherElements["Exercise control"].buttons["Barbell Biceps Curls"].tap()
         
+        // Check that default labels are saved
+        XCTAssertNotNil(app.otherElements["Repetitions"].value)
+        XCTAssertNotNil(app.otherElements["Weight"].value)
+        XCTAssertNotNil(app.otherElements["Intensity"].value)
+        
         // Stop session
         app.otherElements["Exercise control"].buttons["Barbell Biceps Curls"].pressForDuration(6)
     }


### PR DESCRIPTION
When user performs an exercise for the first time and don't change any labels only the duration is saved.

- [x] Add default values in the labels when no prediction is available
- [x] Update UI test